### PR TITLE
Fix import path for eris

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ their application, then wrap it up in the interface I happen to think
 was the most logical. This adds a few very simple things to Dispatch
 to make it suitable for use as a user-friendly I2P IRC client.
 
-BRB also wraps up an IRC server, based on the one found in *[prologic/eris](https://github.com/prologic/eris).*
+BRB also wraps up an IRC server, based on the one found in *[prologic/eris](https://git.mills.io/prologic/eris).*
 This makes it useful as a sort of ad-hoc anonymous groupchat system. Again,
 many thanks to prologic and the other people who have worked on Eris. Eris
 will be configured to listen on an I2P "SAM" connection, just like Dispatch,

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,6 @@ require (
 	i2pgit.org/idk/libbrb v0.0.0-20210212235910-47566bb780a4
 )
 
-replace github.com/prologic/eris => github.com/prologic/eris v1.6.7-0.20210430033226-64d4acc46ca7
+replace git.mills.io/prologic/eris => git.mills.io/prologic/eris v1.6.7-0.20210430033226-64d4acc46ca7
 
 replace i2pgit.org/idk/libbrb => ../../../i2pgit.org/idk/libbrb

--- a/go.sum
+++ b/go.sum
@@ -457,8 +457,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
-github.com/prologic/eris v1.6.7-0.20210430033226-64d4acc46ca7 h1:msmkJRmgaNlFlKosza41CWNPkYwQyOwRcIpWA5gFrQ4=
-github.com/prologic/eris v1.6.7-0.20210430033226-64d4acc46ca7/go.mod h1:4y/W8p1NQTA7UR5mH2HDSFxBvuY0N/VSVj2mokpt2sQ=
+git.mills.io/prologic/eris v1.6.7-0.20210430033226-64d4acc46ca7 h1:msmkJRmgaNlFlKosza41CWNPkYwQyOwRcIpWA5gFrQ4=
+git.mills.io/prologic/eris v1.6.7-0.20210430033226-64d4acc46ca7/go.mod h1:4y/W8p1NQTA7UR5mH2HDSFxBvuY0N/VSVj2mokpt2sQ=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829/go.mod h1:p2iRAGwDERtqlqzRXnrOVns+ignqQo//hLXqYxZYVNs=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@ their application, then wrap it up in the interface I happen to think
 was the most logical. This adds a few very simple things to Dispatch
 to make it suitable for use as a user-friendly I2P IRC client.</p>
 
-<p>BRB also wraps up an IRC server, based on the one found in <em><a href="https://github.com/prologic/eris">prologic/eris</a>.</em>
+<p>BRB also wraps up an IRC server, based on the one found in <em><a href="https://git.mills.io/prologic/eris">prologic/eris</a>.</em>
 This makes it useful as a sort of ad-hoc anonymous groupchat system. Again,
 many thanks to prologic and the other people who have worked on Eris. Eris
 will be configured to listen on an I2P "SAM" connection, just like Dispatch,


### PR DESCRIPTION
Project has moved to [git.mills.io/prologic/eris](https://git.mills.io/prologic/eris).

For details on why see: https://github.com/prologic

Thank you! 🙇